### PR TITLE
fix: 修复切换tab时 默认高度没了，导致startIndex 计算错误

### DIFF
--- a/packages/virtual-table/src/core/body.tsx
+++ b/packages/virtual-table/src/core/body.tsx
@@ -16,6 +16,7 @@ import { useMergedRef } from '../utils/ref'
 import Colgroup from './colgroup'
 import { useScrollSynchronize } from './context/horizontal-scroll'
 import { TableRowManager } from './context/row-manager'
+import { useNodeHeight } from './hooks/useNodeHeight'
 import { NormalRowHeightKey, useRowVirtualize } from './hooks/useRowVirtualize'
 import { pipelineRender } from './pipeline/render-pipeline'
 import Row from './row'
@@ -73,6 +74,8 @@ function TableBody<T>(props: TableBodyProps<T>) {
     renderCell,
   } = props
 
+  const [tbodyNode, nodeHeightValid] = useNodeHeight()
+
   const {
     startIndex,
     endIndex,
@@ -84,6 +87,7 @@ function TableBody<T>(props: TableBodyProps<T>) {
     topBlank,
     bottomBlank,
   } = useRowVirtualize({
+    nodeHeightValid,
     getOffsetTop,
     rowKey,
     dataSource: rawData,
@@ -97,7 +101,7 @@ function TableBody<T>(props: TableBodyProps<T>) {
     getRowHeightMap: () => rowHeightByRowKey.current,
   } satisfies Partial<TableInstanceBuildIn>)
 
-  const tbodyRef = useMergedRef(bodyRef, (elm) => {
+  const tbodyRef = useMergedRef(bodyRef, tbodyNode, (elm) => {
     if (elm == null) return
 
     const bodyHeight = elm.offsetHeight

--- a/packages/virtual-table/src/core/hooks/useNodeHeight.ts
+++ b/packages/virtual-table/src/core/hooks/useNodeHeight.ts
@@ -1,0 +1,14 @@
+import { useRef } from 'react'
+import { useStableFn } from './useStableFn'
+
+export function useNodeHeight<T extends HTMLElement>() {
+  const nodeRef = useRef<T>(null)
+
+  const getIsVisible = useStableFn(() => {
+    const node = nodeRef.current
+    if (node == null) return false
+    return node.offsetHeight > 0
+  })
+
+  return [nodeRef, getIsVisible] as const
+}

--- a/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
+++ b/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
@@ -106,7 +106,14 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
       const key = getRowKey(item, rowKey)
       const row = rowHeightByRowKey.current.get(key) ?? new Map<Key, number>()
       const target = row.get(NormalRowHeightKey)
-      if (target == null) {
+
+      /**
+       * target = 0 是因为一开始从有滚动条，切换tab 然后变成了没滚动条，
+       * 然后触发render 但是这个row 是已经挂载了的，没触发ref的计算，但是却重新触发了fillrowheight
+       * 那么他应该重新给个默认值吧
+       * 如果这里没有默认值，会导致后面计算startIndex 计算错误
+       */
+      if (target == null || target === 0) {
         row.set(NormalRowHeightKey, estimateSize)
       }
       rowHeightByRowKey.current.set(key, row)
@@ -129,7 +136,6 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
   const updateRowRects = () => {
     const { rects } = rawData.reduce((result, rowData, index) => {
       const key = getRowKey(rowData, rowKey)
-
       let height = 0
       rowHeightByRowKey.current.get(key)?.forEach((item) => {
         height += item

--- a/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
+++ b/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
@@ -3,7 +3,7 @@
 import type { Key, MutableRefObject } from 'react'
 import type { ScrollElement } from '../../utils/dom'
 import type { NecessaryProps } from '../internal'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { getScrollElement, isRoot, isWindow } from '../../utils/dom'
 import { getRowKey } from '../utils/get-key'
 import { onResize } from '../utils/on-resize'
@@ -16,6 +16,7 @@ export interface RowRect {
 }
 
 interface UseRowVirtualizeOptions<T = any> {
+  nodeHeightValid: () => boolean
   getOffsetTop: () => number
   dataSource: T[]
   rowKey: NecessaryProps<T>['rowKey']
@@ -51,6 +52,7 @@ export const NormalRowHeightKey = 'NormalRow'
 
 export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
   const {
+    nodeHeightValid,
     getOffsetTop,
     rowKey,
     dataSource: rawData,
@@ -61,6 +63,20 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
 
   const [startIndex, setStartIndex] = useState(0)
   const [endIndex, setEndIndex] = useState(0)
+
+  // 解决 PR #5 的问题
+  // 在 scroll 事件中获取到当前的 node 高度为 0 就认为节点不可见，
+  // 就不需要触发 updateBoundary
+  // 把它推迟到下一次渲染检测 node 高度不为 0 的时候
+  const reUpdateBoundary = useRef<() => void>()
+  useLayoutEffect(() => {
+    const reUpdate = reUpdateBoundary.current
+    if (reUpdate == null) return
+    if (nodeHeightValid()) {
+      reUpdate()
+      reUpdateBoundary.current = undefined
+    }
+  })
 
   const dataSlice = useMemo(() => {
     return rawData.slice(startIndex, endIndex)
@@ -225,20 +241,30 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
       if (isScrollDown) {
         // 如果滚动距离比较小，没有超出锚点元素的边界，就不需要计算 startIndex、endIndex 了
         if (scrollTop > anchorRef.current.bottom) {
-          updateBoundary(scrollTop)
+          if (!nodeHeightValid()) {
+            reUpdateBoundary.current = () => updateBoundary(scrollTop)
+          } else {
+            updateBoundary(scrollTop)
+          }
         }
       } else {
         if (scrollTop < anchorRef.current.top) {
-          updateBoundary(scrollTop)
+          if (!nodeHeightValid()) {
+            reUpdateBoundary.current = () => updateBoundary(scrollTop)
+          } else {
+            updateBoundary(scrollTop)
+          }
         }
       }
-
       scrollTopRef.current = scrollTop
     }
 
     let prevHeight = 0
     const stopListen = onResize(container, (rect) => {
-      // 处理父元素 display:none 容器高度丢失，导致显示 row 不准确
+      // 使用 div 作为滚动容器时，并且放置在 <Tabs> 组件内，当前 tab 切换到非激活状态时，
+      // 父元素会被设置 display:none，导致容器高度变为 0，导致调用 updateBoundary
+      // 来回切换会发现每一次都会往下移动几个 row
+      // 这里加一个判断，rect.height 为0时，不处理本次的 resize 事件（这就是 display:none）
       if (rect.height === prevHeight || rect.height === 0) {
         return
       }
@@ -265,7 +291,7 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
       stopListen()
       container.removeEventListener('scroll', onScroll)
     }
-  }, [estimateSize, getOffsetTop, getScroller, overscan, updateBoundaryFlagDep])
+  }, [estimateSize, getOffsetTop, getScroller, overscan, updateBoundaryFlagDep, nodeHeightValid])
 
   const sum = (startIndex: number, endIndex?: number) => {
     return rowHeights.current.slice(startIndex, endIndex).reduce((a, b) => a + b, 0)

--- a/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
+++ b/packages/virtual-table/src/core/hooks/useRowVirtualize.ts
@@ -122,14 +122,7 @@ export function useRowVirtualize<T = any>(options: UseRowVirtualizeOptions<T>) {
       const key = getRowKey(item, rowKey)
       const row = rowHeightByRowKey.current.get(key) ?? new Map<Key, number>()
       const target = row.get(NormalRowHeightKey)
-
-      /**
-       * target = 0 是因为一开始从有滚动条，切换tab 然后变成了没滚动条，
-       * 然后触发render 但是这个row 是已经挂载了的，没触发ref的计算，但是却重新触发了fillrowheight
-       * 那么他应该重新给个默认值吧
-       * 如果这里没有默认值，会导致后面计算startIndex 计算错误
-       */
-      if (target == null || target === 0) {
+      if (target == null) {
         row.set(NormalRowHeightKey, estimateSize)
       }
       rowHeightByRowKey.current.set(key, row)


### PR DESCRIPTION
<img width="323" height="947" alt="e4226cd953ce5bd866137c600fd8e0f0" src="https://github.com/user-attachments/assets/0da52af9-b4c8-4164-81b3-fe7b15f66ddb" />
